### PR TITLE
LOGIST-1070 - Wrong log when CI-bully closes a PR

### DIFF
--- a/github.go
+++ b/github.go
@@ -51,12 +51,10 @@ func actions(currentPr prType) {
 
 	if arguments["--enable"].(bool) {
 		commentOnPr(currentPr, actionTaken.Message)
-		switch actionTaken.Action {
-		case "close":
+		if actionTaken.Action == "close" {
 			closePr(currentPr)
-		default:
-			fmt.Printf("[%s]\n", actionTaken.Action)
 		}
+		fmt.Printf("[%s]\n", actionTaken.Action)
 	} else {
 		fmt.Printf("[%s 'DRY MODE']\n", actionTaken.Action)
 	}


### PR DESCRIPTION
Just prints the action that was executed in the PR at the end of each line.